### PR TITLE
Add agent bot configuration

### DIFF
--- a/docs/AI/_order.yaml
+++ b/docs/AI/_order.yaml
@@ -1,6 +1,10 @@
 - index
 - agents-config
 - agent-chat
+- messaging-channels
+- messaging-channels-slack
+- messaging-channels-microsoft-teams
+- messaging-channels-discord
 - agent-building-101
 - agent-instructions-guide
 - agent-tools-and-permissions

--- a/docs/AI/agent-chat.md
+++ b/docs/AI/agent-chat.md
@@ -90,6 +90,7 @@ If Agent Chat does not work as expected:
 ## Related guides
 
 * [Agents config](doc:agents-config)
+* [Messaging channels](doc:messaging-channels)
 * [Chatbox component](doc:chatbox)
 * [Agent building 101](doc:agent-building-101)
 * [Agent testing guide](doc:agent-testing-guide)

--- a/docs/AI/index.md
+++ b/docs/AI/index.md
@@ -17,6 +17,9 @@ next:
       slug: agent-chat
       title: Agent chat
     - type: basic
+      slug: messaging-channels
+      title: Messaging channels
+    - type: basic
       slug: agent-building-101
       title: Agent building 101
 ---
@@ -30,19 +33,21 @@ Use this section to go from initial setup to production-ready Agent workflows.
    Connect and validate your provider and default model, then attach a model to your agent.
 2. [Agent chat](doc:agent-chat)  
    Configure chat deployment, agent availability, access role, and conversation starters.
-3. [Agent building 101](doc:agent-building-101)  
+3. [Messaging channels](doc:messaging-channels)  
+   Deploy the same live agent to Slack, Microsoft Teams, or Discord after Agent Chat is validated.
+4. [Agent building 101](doc:agent-building-101)  
    Build a complete service desk Agent with tools and automation handoff.
-4. [Agent instructions guide](doc:agent-instructions-guide)  
+5. [Agent instructions guide](doc:agent-instructions-guide)  
    Write clear, safe, and deterministic instruction prompts.
-5. [Agent tools and permissions](doc:agent-tools-and-permissions)  
+6. [Agent tools and permissions](doc:agent-tools-and-permissions)  
    Apply least-privilege tool access and safe write guardrails.
-6. [Agent embedding models](doc:agent-embedding-models)  
+7. [Agent embedding models](doc:agent-embedding-models)  
    Configure embeddings for Agent knowledge retrieval.
-7. [Agent vector databases](doc:agent-vector-databases)  
+8. [Agent vector databases](doc:agent-vector-databases)  
    Connect and assign vector storage for semantic retrieval.
-8. [Agent testing guide](doc:agent-testing-guide)  
+9. [Agent testing guide](doc:agent-testing-guide)  
    Run repeatable tests and regression checks before production rollout.
-9. [Agent troubleshooting](doc:agent-troubleshooting)  
+10. [Agent troubleshooting](doc:agent-troubleshooting)  
    Diagnose model, tool, and output issues quickly.
 
 ## What this section covers

--- a/docs/AI/messaging-channels-discord.md
+++ b/docs/AI/messaging-channels-discord.md
@@ -1,0 +1,63 @@
+---
+title: Discord messaging channel
+deprecated: false
+hidden: false
+metadata:
+  robots: index
+---
+Use this guide to deploy an agent to Discord after validating [Agent chat](doc:agent-chat).
+
+## Before you start
+
+Make sure you have:
+
+* A Discord application and bot
+* A Discord server (guild) where you can install the bot
+* A live agent with an AI model connected
+* Access to **Agents** -> your agent -> **Deployment**
+
+## Configure Discord in Budibase
+
+1. Open your agent in **Agents**
+2. Go to **Deployment**
+3. In **Messaging channels**, click **Manage** for **Discord**
+4. Enter:
+   * **Application ID**
+   * **Public key**
+   * **Bot token**
+   * **Guild ID**
+   * **Idle timeout (minutes)** (optional)
+5. Click **Enable channel**
+6. Copy:
+   * **Discord invite URL**
+   * **Webhook URL**
+
+## Configure your Discord app
+
+1. Use the generated **Discord invite URL** to add the bot to your server
+2. In the Discord Developer Portal, set the interactions endpoint to the Budibase **Webhook URL**
+3. Save the interactions endpoint configuration
+
+When channel enable runs successfully, Budibase syncs `/ask` and `/new` commands.
+
+## Enable and verify
+
+1. In Budibase **Deployment**, confirm Discord is **Enabled**
+2. In Discord, run:
+   * `/ask` with a message
+   * `/new` to start a new conversation
+3. Confirm responses appear in Discord
+
+## Troubleshooting
+
+* `Not connected` in Budibase: confirm all four required values are saved.
+* Command sync fails: re-check **Application ID**, **Bot token**, and **Guild ID**.
+* Interactions fail: verify the Discord interactions endpoint exactly matches the Budibase **Webhook URL**.
+* Signature validation errors: confirm **Public key** matches the key in your Discord application.
+* Webhook route errors: use the exact Budibase-generated endpoint URL from **Deployment**.
+
+## Related guides
+
+* [Messaging channels](doc:messaging-channels)
+* [Slack messaging channel](doc:messaging-channels-slack)
+* [Microsoft Teams messaging channel](doc:messaging-channels-microsoft-teams)

--- a/docs/AI/messaging-channels-microsoft-teams.md
+++ b/docs/AI/messaging-channels-microsoft-teams.md
@@ -1,0 +1,59 @@
+---
+title: Microsoft Teams messaging channel
+deprecated: false
+hidden: false
+metadata:
+  robots: index
+---
+Use this guide to deploy an agent to Microsoft Teams after validating [Agent chat](doc:agent-chat).
+
+## Before you start
+
+Make sure you have:
+
+* A Microsoft 365 tenant with Teams access
+* An Azure app registration for your bot
+* A live agent with an AI model connected
+* Access to **Agents** -> your agent -> **Deployment**
+
+## Configure Microsoft Teams in Budibase
+
+1. Open your agent in **Agents**
+2. Go to **Deployment**
+3. In **Messaging channels**, click **Manage** for **Microsoft Teams**
+4. Enter:
+   * **App ID (client ID)**
+   * **Client secret (value)**
+   * **Directory (tenant) ID (Azure AD tenant ID)**
+   * **Idle timeout (minutes)** (optional)
+5. Click **Save channel**
+6. Copy the generated **Messaging endpoint URL**
+
+## Configure your Teams bot endpoint
+
+In your Azure bot configuration, set the bot messaging endpoint to the Budibase **Messaging endpoint URL**.
+
+Use a single-tenant setup that matches your tenant ID.
+
+## Enable and verify
+
+1. In Budibase **Deployment**, toggle Microsoft Teams to **Enabled**
+2. Open Teams and message the bot
+3. Test commands:
+   * `ask <message>` to continue the current conversation
+   * `new <message>` to start a new conversation
+
+Plain text messages are treated as `ask`.
+
+## Troubleshooting
+
+* `Not configured` in Budibase: confirm **App ID**, **Client secret**, and **Tenant ID** are saved.
+* Teams cannot deliver messages: verify the bot messaging endpoint matches the Budibase URL exactly.
+* Authentication failures from Teams: check bot credentials and tenant alignment.
+* Webhook route errors: use the exact Budibase-generated endpoint URL from **Deployment**.
+
+## Related guides
+
+* [Messaging channels](doc:messaging-channels)
+* [Slack messaging channel](doc:messaging-channels-slack)
+* [Discord messaging channel](doc:messaging-channels-discord)

--- a/docs/AI/messaging-channels-slack.md
+++ b/docs/AI/messaging-channels-slack.md
@@ -1,0 +1,89 @@
+---
+title: Slack messaging channel
+deprecated: false
+hidden: false
+metadata:
+  robots: index
+---
+Use this guide to deploy an agent to Slack after confirming [Agent chat](doc:agent-chat).
+
+## Before you start
+
+Make sure you have:
+
+* A Slack workspace where you can create apps
+* A live agent with an AI model connected
+* Access to **Agents** -> your agent -> **Deployment**
+
+## Configure Slack in Budibase
+
+1. Open your agent in **Agents**
+2. Go to **Deployment**
+3. In **Messaging channels**, click **Manage** for **Slack**
+4. Enter:
+   * **Bot token**
+   * **Signing secret**
+   * **Idle timeout (minutes)** (optional)
+5. Click **Save channel**
+6. Copy the generated **Messaging endpoint URL**
+
+## Configure your Slack app
+
+### 1. Create or update app
+
+Create a Slack app for your workspace, or use an existing one.
+
+### 2. Add bot scopes
+
+In **OAuth & Permissions**, add:
+
+* `chat:write`
+* `app_mentions:read`
+* `im:history`
+* `channels:history`
+* `groups:history`
+* `mpim:history`
+* `users:read`
+
+### 3. Configure event subscriptions
+
+1. Open **Event Subscriptions**
+2. Enable events
+3. Set **Request URL** to the Budibase **Messaging endpoint URL**
+4. Subscribe to bot events:
+   * `app_mention`
+   * `message.im`
+   * `message.channels`
+   * `message.groups`
+   * `message.mpim`
+
+### 4. Reinstall app
+
+Reinstall the app to your workspace after changing scopes or events.
+
+### 5. Invite bot
+
+Invite the bot to channels you want it to serve, for example:
+
+`/invite @your-bot`
+
+## Enable and verify
+
+1. In Budibase **Deployment**, toggle Slack to **Enabled**
+2. In Slack, mention the bot in a channel or send a DM
+3. Confirm the agent responds
+
+Slack threads are used as conversation boundaries automatically.
+
+## Troubleshooting
+
+* `Not configured` in Budibase: confirm both **Bot token** and **Signing secret** are saved.
+* Slack events not reaching Budibase: re-check **Request URL** and reinstall the app after scope/event changes.
+* Bot does not respond in channels: confirm the bot was invited to that channel.
+* Webhook route errors: use the exact Budibase-generated endpoint URL from **Deployment**.
+
+## Related guides
+
+* [Messaging channels](doc:messaging-channels)
+* [Microsoft Teams messaging channel](doc:messaging-channels-microsoft-teams)
+* [Discord messaging channel](doc:messaging-channels-discord)

--- a/docs/AI/messaging-channels.md
+++ b/docs/AI/messaging-channels.md
@@ -1,0 +1,42 @@
+---
+title: Messaging channels
+deprecated: false
+hidden: false
+metadata:
+  robots: index
+---
+Use this page to deploy an agent to external messaging channels after [Agent chat](doc:agent-chat) is working.
+
+Agent chat is the recommended first deployment path. Slack, Microsoft Teams, and Discord are optional channels for users who need agent access in existing chat tools.
+
+## Before you start
+
+Make sure you have:
+
+* A working [Agents config](doc:agents-config)
+* A saved agent with a connected AI model
+* An agent set to **Live**
+* `Agent chat` already validated in App Portal
+
+## Recommended rollout order
+
+1. Enable and test [Agent chat](doc:agent-chat)
+2. Configure one external channel
+3. Run end-to-end tests in that channel
+4. Add additional channels only after the first is stable
+
+## Available channel guides
+
+* [Slack](doc:messaging-channels-slack)
+* [Microsoft Teams](doc:messaging-channels-microsoft-teams)
+* [Discord](doc:messaging-channels-discord)
+
+## Important endpoint note
+
+Budibase channel webhooks are validated against the production workspace route. Use the endpoint URL generated in the deployment UI, and do not replace the workspace segment manually.
+
+## Related guides
+
+* [Agent chat](doc:agent-chat)
+* [Agent building 101](doc:agent-building-101)
+* [Agent testing guide](doc:agent-testing-guide)


### PR DESCRIPTION
This PR adds a new AI docs path for deploying agents to external messaging channels, while keeping Agent chat as the first recommended deployment route.

## What changed

- Added a new Messaging channels overview page:
   - docs/AI/messaging-channels.md
- Added channel-specific setup guides:
  - docs/AI/messaging-channels-slack.md
  - docs/AI/messaging-channels-microsoft-teams.md
   - docs/AI/messaging-channels-discord.md
- Updated AI navigation order:
  - docs/AI/_order.yaml
- Updated AI landing page recommended sequence to place Messaging channels after Agent chat:
   - docs/AI/index.md
- Added a related link from Agent chat to Messaging channels:
  - docs/AI/agent-chat.md

## Content approach

- Keeps Agent chat as the baseline deployment path.
- Positions Slack, Teams, and Discord as optional follow-on channels.
- Uses a consistent structure across all channel guides:
  - prerequisites
  - Budibase deployment setup
  - provider-side setup
  - enable/verify
  - troubleshooting
- Uses Budibase UI terms and code-backed channel requirements/flows.