### PR TITLE
content updates deprecate bb chat

### DIFF
--- a/docs/AI/_order.yaml
+++ b/docs/AI/_order.yaml
@@ -1,7 +1,7 @@
 - index
 - agents-config
-- agent-chat
 - messaging-channels
+- agent-chat
 - agent-building-101
 - agent-instructions-guide
 - agent-tools-and-permissions

--- a/docs/AI/agent-building-101.md
+++ b/docs/AI/agent-building-101.md
@@ -228,7 +228,7 @@ In this example, we’ll use an Automation to classify and prioritise tickets as
 
 This gives you a practical split of responsibilities:
 
-* **Agent chat** handles interactive support tasks, Q&A, and guided updates
+* **Messaging channels** handle interactive support tasks, Q&A, and guided updates
 * **Automations** handle repeatable, event-driven triage in the background
 
 Together, these provide a reliable service desk workflow with both human-in-the-loop and fully automatic paths.

--- a/docs/AI/agent-chat.md
+++ b/docs/AI/agent-chat.md
@@ -1,95 +1,42 @@
 ---
 title: Agent chat
-deprecated: false
+deprecated: true
 hidden: false
 metadata:
   robots: index
 ---
-Agent chat is a built-in, user-facing chat app for running your live agents with controlled access.
+Agent chat is deprecated.
 
-Use this page after completing [Agents config](doc:agents-config).
+Budibase is moving to channel-first agent access in tools where users already work day-to-day:
 
-## Before you start
+* [Slack](doc:messaging-channels-slack)
+* [Microsoft Teams](doc:messaging-channels-microsoft-teams)
+* [Discord](doc:messaging-channels-discord)
 
-Make sure you have:
+Use [Messaging channels](doc:messaging-channels) as the primary deployment path.
 
-* A configured model in **Workspace Settings > Connections > AI models**
-* A saved agent with an AI model connected
-* An agent set live (status **Live**)
+## What this means
 
-## Enable agent chat for an agent
+If you are currently using Agent Chat:
 
-1. Open your agent in **Agents**
-2. Go to the **Deployment** tab
-3. Find **Agent Chat**
-4. Use the toggle to enable the channel
+* [Agents config](doc:agents-config)
+* [Messaging channels](doc:messaging-channels)
+* [Slack messaging channel](doc:messaging-channels-slack)
+* [Microsoft Teams messaging channel](doc:messaging-channels-microsoft-teams)
+* [Discord messaging channel](doc:messaging-channels-discord)
 
-When enabled, Budibase updates chat configuration for that agent.
+## Migration checklist
 
-## Configure settings for one agent
-
-From **Agent Chat** click **Manage** to open agent settings.
-
-You can configure:
-
-* **Access role**: Minimum app role required to use that agent in chat
-* **Conversation starters**: Up to 3 starter prompts shown in chat
-
-If the agent status is **Live**, saving these settings will require a workspace publish to apply the changes.
-
-## Access agent chat
-
-Agent chat is accessed from the **App Portal**.
-
-To open the chat app for an agent:
-
-1. Open **Agents**
-2. Select an agent
-3. Open the **Deployment** tab
-4. Click **Open chat**
-
-This takes you directly to the chat screen in the App Portal.
-
-### Access role behavior
-
-* New chat-enabled agents default to `BASIC` access role unless changed
-* Access role can be updated per agent from settings
-
-### Conversation starter behavior
-
-* Starters are stored per agent
-* Empty values are ignored
-* Only the first 3 non-empty starters are kept
-
-
-## Embed chat in app screens
-
-To embed chat inside an app screen, use the [Chatbox component](doc:chatbox) under **Apps**.
-
-## Runtime states users can see
-
-Depending on configuration, users may see:
-
-* No agents configured for chat
-* Agents configured but none enabled
-* Selected agent unavailable for chat
-* No live/deployed chat access for the current setup
-
-When these states appear, verify deployment status and agent chat enablement.
-
-## Troubleshooting
-
-If Agent Chat does not work as expected:
-
-* Confirm [Agents config](doc:agents-config) is valid and the agent has a connected model
-* Confirm the agent status is **Live**
-* Confirm the agent is enabled in Chat settings
-* Open chat from **Agents** -> **Deployment** -> **Open chat** to verify the App Portal route
-* Re-open the chat app after publish to pick up latest settings
+1. Confirm your agent has a connected AI model in [Agents config](doc:agents-config).
+2. Ensure the agent is set to **Live**.
+3. Pick one primary channel (Slack, Teams, or Discord).
+4. Configure the channel in **Agents -> Deployment -> Messaging channels**.
+5. Validate account linking (`/link`, or `link` in Teams).
+6. Run end-to-end tests for conversation continuity and tool actions.
+7. Add additional channels only after the first channel is stable.
 
 ## Related guides
 
-* [Agents config](doc:agents-config)
 * [Messaging channels](doc:messaging-channels)
 * [Chatbox component](doc:chatbox)
 * [Agent building 101](doc:agent-building-101)

--- a/docs/AI/agents-config.md
+++ b/docs/AI/agents-config.md
@@ -5,9 +5,9 @@ hidden: false
 metadata:
   robots: index
 ---
-This page covers the required setup before using Budibase Agents and Agent Chat.
+This page covers the required setup before using Budibase Agents in messaging channels.
 
-Before building an Agent or enabling Agent Chat, you need at least one configured model in **Workspace Settings > Connections > AI models**.
+Before building an Agent or deploying to channels, you need at least one configured model in **Workspace Settings > Connections > AI models**.
 
 For a broader AI setup walkthrough, see [Quickstart: Budibase AI](doc:quickstart-budibase-ai).
 
@@ -75,15 +75,15 @@ After configuring a model in **AI models**, attach it to each agent:
 3. Click **Connect AI Model**
 4. Select the configured provider and model
 
-## Ready for agent chat checklist
+## Ready for channel deployment checklist
 
-Before enabling Agent Chat, confirm:
+Before enabling a channel, confirm:
 
 * Your agent has a connected AI model
 * The selected model can run chat/completion prompts
 * The agent is saved and can answer a simple test prompt
 
-Next, configure chat deployment in [Agent chat](doc:agent-chat).
+Next, configure deployment in [Messaging channels](doc:messaging-channels).
 
 ## Troubleshooting
 
@@ -98,7 +98,7 @@ If you are self-hosting and using Budibase AI, ensure your network allows the re
 
 ## Related guides
 
-* [Agent chat](doc:agent-chat)
+* [Messaging channels](doc:messaging-channels)
 * [Agent building 101](doc:agent-building-101)
 * [Agent instructions guide](doc:agent-instructions-guide)
 * [Agent testing guide](doc:agent-testing-guide)

--- a/docs/AI/index.md
+++ b/docs/AI/index.md
@@ -14,11 +14,11 @@ next:
       slug: agents-config
       title: Agents config
     - type: basic
-      slug: agent-chat
-      title: Agent chat
-    - type: basic
       slug: messaging-channels
       title: Messaging channels
+    - type: basic
+      slug: agent-chat
+      title: Agent chat (deprecated)
     - type: basic
       slug: agent-building-101
       title: Agent building 101
@@ -30,25 +30,25 @@ Use this section to go from initial setup to production-ready Agent workflows.
 ## Recommended path
 
 1. [Agents config](doc:agents-config)  
-   Connect and validate your provider and default model, then attach a model to your agent.
-2. [Agent chat](doc:agent-chat)  
-   Configure chat deployment, agent availability, access role, and conversation starters.
-3. [Messaging channels](doc:messaging-channels)  
-   Deploy the same live agent to Slack, Microsoft Teams, or Discord after Agent Chat is validated.
-4. [Agent building 101](doc:agent-building-101)  
-   Build a complete service desk Agent with tools and automation handoff.
-5. [Agent instructions guide](doc:agent-instructions-guide)  
-   Write clear, safe, and deterministic instruction prompts.
-6. [Agent tools and permissions](doc:agent-tools-and-permissions)  
-   Apply least-privilege tool access and safe write guardrails.
-7. [Agent embedding models](doc:agent-embedding-models)  
-   Configure embeddings for Agent knowledge retrieval.
-8. [Agent vector databases](doc:agent-vector-databases)  
-   Connect and assign vector storage for semantic retrieval.
-9. [Agent testing guide](doc:agent-testing-guide)  
-   Run repeatable tests and regression checks before production rollout.
-10. [Agent troubleshooting](doc:agent-troubleshooting)  
-   Diagnose model, tool, and output issues quickly.
+   Connect and validate your provider and default model, then attach a model to your agent
+2. [Messaging channels](doc:messaging-channels)  
+   Deploy your live agent to Slack, Microsoft Teams, or Discord
+3. [Agent building 101](doc:agent-building-101)  
+   Build a complete service desk Agent with tools and automation handoff
+4. [Agent instructions guide](doc:agent-instructions-guide)  
+   Write clear, safe, and deterministic instruction prompts
+5. [Agent tools and permissions](doc:agent-tools-and-permissions)  
+   Apply least-privilege tool access and safe write guardrails
+6. [Agent embedding models](doc:agent-embedding-models)  
+   Configure embeddings for Agent knowledge retrieval
+7. [Agent vector databases](doc:agent-vector-databases)  
+   Connect and assign vector storage for semantic retrieval
+8. [Agent testing guide](doc:agent-testing-guide)  
+   Run repeatable tests and regression checks before production rollout
+9. [Agent troubleshooting](doc:agent-troubleshooting)  
+   Diagnose model, tool, and output issues quickly
+10. [Agent chat](doc:agent-chat)  
+   Deprecated path retained for migration context
 
 ## What this section covers
 

--- a/docs/AI/messaging-channels/index.md
+++ b/docs/AI/messaging-channels/index.md
@@ -5,9 +5,9 @@ hidden: false
 metadata:
   robots: index
 ---
-Use this page to deploy an agent to external messaging channels after [Agent chat](doc:agent-chat) is working.
+Use this page to deploy an agent to external messaging channels where your users already work.
 
-Agent chat is the recommended first deployment path. Slack, Microsoft Teams, and Discord are optional channels for users who need agent access in existing chat tools.
+Slack, Microsoft Teams, and Discord are the primary deployment paths for live agent conversations.
 
 ## Before you start
 
@@ -16,7 +16,6 @@ Make sure you have:
 * A working [Agents config](doc:agents-config)
 * A saved agent with a connected AI model
 * An agent set live (status **Live**)
-* `Agent chat` already validated in App Portal
 
 ## Link requirement for external channels
 
@@ -28,10 +27,10 @@ If a user sends a normal message before linking, Budibase sends a private link p
 
 ## Recommended rollout order
 
-1. Enable and test [Agent chat](doc:agent-chat)
-2. Configure one external channel
-3. Run end-to-end tests in that channel
-4. Add additional channels only after the first is stable
+1. Configure one channel first
+2. Run end-to-end tests in that channel
+3. Add additional channels only after the first is stable
+4. Standardize account linking and support runbooks for each channel
 
 ## Available channel guides
 
@@ -45,6 +44,6 @@ Budibase channel webhooks are validated against the production workspace route. 
 
 ## Related guides
 
-* [Agent chat](doc:agent-chat)
+* [Agent chat (deprecated)](doc:agent-chat)
 * [Agent building 101](doc:agent-building-101)
 * [Agent testing guide](doc:agent-testing-guide)

--- a/docs/AI/messaging-channels/messaging-channels-discord.md
+++ b/docs/AI/messaging-channels/messaging-channels-discord.md
@@ -5,7 +5,7 @@ hidden: false
 metadata:
   robots: index
 ---
-Use this guide to deploy an agent to Discord after validating [Agent chat](doc:agent-chat).
+Use this guide to deploy an agent to Discord.
 
 ## Before you start
 

--- a/docs/AI/messaging-channels/messaging-channels-microsoft-teams.md
+++ b/docs/AI/messaging-channels/messaging-channels-microsoft-teams.md
@@ -5,7 +5,7 @@ hidden: false
 metadata:
   robots: index
 ---
-Use this guide to deploy an agent to Microsoft Teams after validating [Agent chat](doc:agent-chat).
+Use this guide to deploy an agent to Microsoft Teams.
 
 ## Before you start
 

--- a/docs/AI/messaging-channels/messaging-channels-slack.md
+++ b/docs/AI/messaging-channels/messaging-channels-slack.md
@@ -5,7 +5,7 @@ hidden: false
 metadata:
   robots: index
 ---
-Use this guide to deploy an agent to Slack after confirming [Agent chat](doc:agent-chat).
+Use this guide to deploy an agent to Slack.
 
 ## Before you start
 


### PR DESCRIPTION
We’re updating the AI docs to reflect that Budibase Agent Chat is deprecated and that Teams, Slack, and Discord are now the primary deployment channels.

The changes:

1. Convert agent-chat.md into a deprecation and migration guide.
2. Reorder AI docs navigation so Messaging channels is the recommended path.
3. Remove “Agent Chat first” wording from Slack/Teams/Discord setup guides.
4. Update related setup pages (index, agents-config, agent-building-101) so guidance is consistent and channel-first.