### PR TITLE
more specific whitelisting names

### DIFF
--- a/docs/References/whitelisting/external-data-sources.md
+++ b/docs/References/whitelisting/external-data-sources.md
@@ -1,5 +1,5 @@
 ---
-title: External data sources
+title: Cloud data source access
 deprecated: false
 hidden: false
 metadata:
@@ -7,10 +7,10 @@ metadata:
 next:
   pages:
     - slug: self-hosted-licensing
-      title: Self-hosted licensing
+      title: Self-hosted license connectivity
       type: basic
     - slug: self-hosted-ai-features
-      title: Self-hosted AI features
+      title: Self-hosted AI connectivity
       type: basic
 ---
 If you're using Budibase and attempting to connect to your own data sources, you may encounter issues if a firewall is blocking traffic. You will need to allow inbound connections from Budibase to your database server.

--- a/docs/References/whitelisting/index.md
+++ b/docs/References/whitelisting/index.md
@@ -1,8 +1,7 @@
 ---
-title: Whitelisting
+title: Network access
 excerpt: >-
-  Ensuring that your self-hosted installation or Budibase Cloud usage is not
-  disrupted by network conditions.
+  Network access requirements for Budibase Cloud and self-hosted deployments.
 deprecated: false
 hidden: false
 metadata:
@@ -12,13 +11,13 @@ metadata:
 next:
   pages:
     - slug: external-data-sources
-      title: External data sources
+      title: Cloud data source access
       type: basic
     - slug: self-hosted-licensing
-      title: Self-hosted licensing
+      title: Self-hosted license connectivity
       type: basic
     - slug: self-hosted-ai-features
-      title: Self-hosted AI features
+      title: Self-hosted AI connectivity
       type: basic
 ---
 Budibase communicates with your databases, services, and Budibase Cloud infrastructure through a small number of well-defined network endpoints. If your environment uses a firewall, proxy, or private network, you may need to whitelist specific IP addresses or domains to ensure Budibase operates correctly.

--- a/docs/References/whitelisting/self-hosted-ai-features.md
+++ b/docs/References/whitelisting/self-hosted-ai-features.md
@@ -1,5 +1,5 @@
 ---
-title: Self-hosted AI features
+title: Self-hosted AI connectivity
 deprecated: false
 hidden: false
 metadata:
@@ -7,7 +7,7 @@ metadata:
 next:
   pages:
     - slug: self-hosted-licensing
-      title: Self-hosted licensing
+      title: Self-hosted license connectivity
       type: basic
 ---
 <br />

--- a/docs/References/whitelisting/self-hosted-licensing.md
+++ b/docs/References/whitelisting/self-hosted-licensing.md
@@ -1,5 +1,5 @@
 ---
-title: Self-hosted licensing
+title: Self-hosted license connectivity
 deprecated: false
 hidden: false
 metadata:
@@ -7,7 +7,7 @@ metadata:
 next:
   pages:
     - slug: self-hosted-ai-features
-      title: Self-hosted AI features
+      title: Self-hosted AI connectivity
       type: basic
 ---
 Self-hosted deployments of Budibase require communication with the Budibase Account Portal for license activation and validation.


### PR DESCRIPTION
Changed the whitelisting names to be more specific so users more easily understand what each page does.