### PR TITLE
docs: document helm alb logging and resolver settings

### DIFF
--- a/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
+++ b/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
@@ -18,7 +18,7 @@ next:
       title: Reverse proxy
 ---
 <HTMLBlock>{`
-<div style="padding:65% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/712765075?h=b87fb892b5&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="k8-deployment.mp4"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
+<div style="padding:65% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/712765075?h=b87fb892b5&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="k8s-deployment.mp4"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 `}</HTMLBlock>
 
 There are a few command-line utilities we have to set up before we can get started with Budibase on Kubernetes. Follow the guides below to set up Kubectl and Helm.
@@ -72,27 +72,27 @@ If you want to make use of `HorizontalPodAutoscaler` resources you will also nee
 
 Now that you have your Kubernetes cluster up and running, you can install the Budibase Helm chart which will provision all of the relevant services for running Budibase in a Kubernetes environment. Run the command below to install the chart from our OCI registry.
 
-```shell
+shell
 helm install --create-namespace --namespace budibase budibase oci://ghcr.io/budibase/charts/budibase
-```
+
 
 Wait a few moments as Budibase creates all the containers and resources. You can then run:
 
-```shell
+shell
 kubectl get pods -n budibase
-```
+
 
 You should now be able to see your new Budibase installation up and running in your Kubernetes cluster.
 
-```
-NAME                              READY   STATUS             RESTARTS         AGE
+
+NAME                                READY   STATUS             RESTARTS         AGE
 app-service-69b7888b7-h25cp       1/1     Running            0                90m
 budibase-couchdb-0                1/1     Running            0                90m
 minio-service-59c757bb5-q6xt2     1/1     Running            0                90m
 proxy-service-6449dd9fdf-v5r6z    1/1     Running            0                90m
 redis-service-c6f59dcf5-lh7v5     1/1     Running            0                90m
 worker-service-55b49f4cdc-qr5b7   1/1     Running            0                90m
-```
+
 
 ## Configuring your Ingress resource
 
@@ -100,19 +100,27 @@ To use your new installation, you'll need to configure an Ingress resource. One 
 
 ### AWS EKS
 
-If you're running on AWS EKS, we ship an ALB-ready Ingress resource as part of the chart. You'll need to disable the deafult Ingress and enable the ALB one:
+If you're running on AWS EKS, we ship an ALB-ready Ingress resource as part of the chart. You'll need to disable the default Ingress and enable the ALB one:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true
-```
+
+
+If you want to enable ALB access logging to S3, you can set the following values during install or upgrade:
+
+shell
+--set awsAlbIngress.accessLogs.enabled=true --set awsAlbIngress.accessLogs.bucket=my-access-logs-bucket --set awsAlbIngress.accessLogs.prefix=budibase
+
+
+*Note: The S3 bucket must already exist in the same region as the ALB and have a bucket policy allowing the regional ELB log-delivery principal to write to it.*
 
 After a few minutes your new Ingress resource should be provisioned and you should be able to get the address for it like so:
 
-```shell
+shell
 $ kubectl --context qa -n budibase get ingress
-NAME               CLASS    HOSTS   ADDRESS                                                                 PORTS   AGE
+NAME               CLASS    HOSTS   ADDRESS                                                       PORTS   AGE
 ingress-budibase   <none>   *       4372843243278.eu-west-1.elb.amazonaws.com   80      9m5s
-```
+
 
 Visit the Ingress address in your browser and you will see that your Budibase installation is up and running.
 
@@ -122,9 +130,9 @@ Visit the Ingress address in your browser and you will see that your Budibase in
 
 If you'd like to set up HTTPS, you can also create a certificate using [AWS ACM](https://aws.amazon.com/certificate-manager/) and specify the certificate ARN on your Ingress resource:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true --set awsAlbIngress.certificateArn=...
-```
+
 
 From here, if you'd like to use a custom domain name make sure it's a CNAME that points to Ingress address and that your certificate includes the custom domain name.
 
@@ -132,7 +140,7 @@ From here, if you'd like to use a custom domain name make sure it's a CNAME that
 
 If you're using `ingress-nginx` in your cluster, you'll want to configure an Ingress something like this (replacing `example.com` with whatever custom domain you would like to point at your Budibase installation):
 
-```yaml
+yaml
 ingress:
   enabled: true
   className: "nginx"
@@ -146,20 +154,20 @@ ingress:
               name: proxy-service
               port:
                 number: 10000
-```
+
 
 Save this as a file called `values.yaml` and then upgrade your Helm release:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
-```
+
 
 Now find the external address if your `ingress-nginx` installation by running:
 
-```shell
-❯ kubectl -n ingress-nginx get services | grep LoadBalancer
-ingress-nginx-controller                   LoadBalancer   10.99.103.243    192.168.0.90   80:32221/TCP,443:32172/TCP   2y20d
-```
+shell
+➜ kubectl -n ingress-nginx get services | grep LoadBalancer
+ingress-nginx-controller                 LoadBalancer   10.99.103.243    192.168.0.90   80:32221/TCP,443:32172/TCP   2y20d
+
 
 If you're running a homelab with, for example, [metallb](https://metallb.org/), your `ingress-nginx` `LoadBalancer` will be exposed on an IP address in your local network as above (`192.168.0.90`). If you're running `ingress-nginx` in EKS, you'll see an AWS load balancer domain name in this column instead.
 
@@ -171,7 +179,7 @@ If `ingress-nginx` is exposed with an IP address, create an `A` record in your D
 
 First, make sure you've followed the steps to [install the Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html). After you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
 
-```yaml
+yaml
 couchdb:
   persistentVolume:
     enabled: true
@@ -182,19 +190,19 @@ services:
     storageClass: "gp3"
   redis:
     storageClass: "gp3"
-```
+
 
 And then update your Budibase installation:
 
-```
+
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
-```
+
 
 ### GCP GKE
 
 Follow the [guide to enable Compute Engine persistent disk](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver) in your GKE cluster. When you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
 
-```
+
 couchdb:
   persistentVolume:
     enabled: true
@@ -205,21 +213,21 @@ services:
     storageClass: "standard-rwo"
   redis:
     storageClass: "standard-rwo"
-```
+
 
 And then update your Budibase installation:
 
-```
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
-```
+
 
 ## Upgrading your Budibase version
 
 To upgrade to the latest version of Budibase via Helm, you can run the following command:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --reuse-values
-```
+
 
 ***
 
@@ -229,7 +237,7 @@ helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --reuse
 
 You can scale up the number of pods in your installation by updating the `replicaCount` of a given service in the `values.yaml` of the Budibase helm chart. For example, if we wanted to scale up the worker and app service due to high load, we can update our `values.yaml` to have a higher `replicaCount`. Once updated, upgrade your chart to apply the changes.
 
-```yaml
+yaml
 services:
   proxy:
     replicaCount: 1
@@ -237,7 +245,7 @@ services:
     replicaCount: 2
   worker:
     replicaCount: 2
-```
+
 
 ### Secrets Management
 
@@ -249,7 +257,7 @@ If you have createSecrets set to true in your `values.yaml`, Budibase will creat
 * Object store secret key (if using MinIO)\
   If you need to read the value of your secrets, you can do so using `kubectl` and the following commands to read the values out from your k8s secrets:
 
-```shell
+shell
 # for internal API key
 kubectl get secret budibase-budibase -o go-template='{{ .data.internalApiKey }}' -n budibase | base64 --decode
 
@@ -261,45 +269,45 @@ kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreAccess 
 
 # MinIO Secret Key
 kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreSecret }}' -n budibase | base64 --decode
-```
+
 
 ### Redis
 
 The Budibase Helm chart ships with a [Redis](https://redis.io/) server that will be included by default. If you want to use your own external Redis cluster, you can configure the `values.yaml` file in the helm chart to switch off the Budibase one by turning enabled off. Here's what your configuration may look like if you wanted to disable the default bundled Redis and use an external Redis cluster hosted on `myrediscluster.io`.
 
-```yaml yaml
+yaml yaml
   services:
     redis:
       enabled: false
       port: 6379
       url: "myrediscluster.io"
       password: "your-redis-password"
-```
+
 
 ### CouchDB
 
 The Budibase Helm chart will automatically bring up a one-node CouchDB cluster within your Kubernetes cluster. If you would rather use an existing CouchDB cluster, you can turn off the one Budibase supplies and point at your own. Please note - you must set up search in your [CouchDB cluster](https://docs.couchdb.org/en/stable/ddocs/search.html) in order to use all the search functionality that Budibase provides. Below is an example configuration of how you would point Budibase to a CouchDB installation hosted on `mycouch.io`:
 
-```yaml
+yaml
   services:
     couchdb:
       enabled: false
       url: "http://mycouch.io:1234"
       user: "couchuser"
       password: "couchpassword"
-```
+
 
 ### MinIO/Amazon S3
 
 Budibase ships with a MinIO server included for object storage. Since MinIO is Amazon S3 compliant, you can switch out the bundled MinIO for an S3 bucket in your AWS account. Here's how your **values.yaml** should look if you want to use S3 instead of MinIO.
 
-```yaml
+yaml
 services:  
   objectStore:
     minio: false
     accessKey: "your-access-key" # AWS_ACCESS_KEY
     secretKey: "your-secret-key" # AWS_SECRET_ACCESS_KEY
-```
+
 
 ### Reference
 

--- a/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
+++ b/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
@@ -18,7 +18,7 @@ next:
       title: Reverse proxy
 ---
 <HTMLBlock>{`
-<div style="padding:65% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/712765075?h=b87fb892b5&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="k8s-deployment.mp4"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
+<div style="padding:65% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/712765075?h=b87fb892b5&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="k8-deployment.mp4"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 `}</HTMLBlock>
 
 There are a few command-line utilities we have to set up before we can get started with Budibase on Kubernetes. Follow the guides below to set up Kubectl and Helm.
@@ -72,14 +72,16 @@ If you want to make use of `HorizontalPodAutoscaler` resources you will also nee
 
 Now that you have your Kubernetes cluster up and running, you can install the Budibase Helm chart which will provision all of the relevant services for running Budibase in a Kubernetes environment. Run the command below to install the chart from our OCI registry.
 
-shell
+```shell
 helm install --create-namespace --namespace budibase budibase oci://ghcr.io/budibase/charts/budibase
+```
 
 
 Wait a few moments as Budibase creates all the containers and resources. You can then run:
 
-shell
+```shell
 kubectl get pods -n budibase
+```
 
 
 You should now be able to see your new Budibase installation up and running in your Kubernetes cluster.
@@ -102,24 +104,27 @@ To use your new installation, you'll need to configure an Ingress resource. One 
 
 If you're running on AWS EKS, we ship an ALB-ready Ingress resource as part of the chart. You'll need to disable the default Ingress and enable the ALB one:
 
-shell
+```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true
+```
 
 
 If you want to enable ALB access logging to S3, you can set the following values during install or upgrade:
 
-shell
+```shell
 --set awsAlbIngress.accessLogs.enabled=true --set awsAlbIngress.accessLogs.bucket=my-access-logs-bucket --set awsAlbIngress.accessLogs.prefix=budibase
+```
 
 
 *Note: The S3 bucket must already exist in the same region as the ALB and have a bucket policy allowing the regional ELB log-delivery principal to write to it.*
 
 After a few minutes your new Ingress resource should be provisioned and you should be able to get the address for it like so:
 
-shell
+```shell
 $ kubectl --context qa -n budibase get ingress
-NAME               CLASS    HOSTS   ADDRESS                                                       PORTS   AGE
+NAME               CLASS    HOSTS   ADDRESS                                                                 PORTS   AGE
 ingress-budibase   <none>   *       4372843243278.eu-west-1.elb.amazonaws.com   80      9m5s
+```
 
 
 Visit the Ingress address in your browser and you will see that your Budibase installation is up and running.
@@ -130,8 +135,9 @@ Visit the Ingress address in your browser and you will see that your Budibase in
 
 If you'd like to set up HTTPS, you can also create a certificate using [AWS ACM](https://aws.amazon.com/certificate-manager/) and specify the certificate ARN on your Ingress resource:
 
-shell
+```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true --set awsAlbIngress.certificateArn=...
+```
 
 
 From here, if you'd like to use a custom domain name make sure it's a CNAME that points to Ingress address and that your certificate includes the custom domain name.
@@ -140,7 +146,7 @@ From here, if you'd like to use a custom domain name make sure it's a CNAME that
 
 If you're using `ingress-nginx` in your cluster, you'll want to configure an Ingress something like this (replacing `example.com` with whatever custom domain you would like to point at your Budibase installation):
 
-yaml
+```yaml
 ingress:
   enabled: true
   className: "nginx"
@@ -154,19 +160,22 @@ ingress:
               name: proxy-service
               port:
                 number: 10000
+```
 
 
 Save this as a file called `values.yaml` and then upgrade your Helm release:
 
-shell
+```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
+```
 
 
 Now find the external address if your `ingress-nginx` installation by running:
 
-shell
+```shell
 ➜ kubectl -n ingress-nginx get services | grep LoadBalancer
-ingress-nginx-controller                 LoadBalancer   10.99.103.243    192.168.0.90   80:32221/TCP,443:32172/TCP   2y20d
+ingress-nginx-controller                   LoadBalancer   10.99.103.243    192.168.0.90   80:32221/TCP,443:32172/TCP   2y20d
+```
 
 
 If you're running a homelab with, for example, [metallb](https://metallb.org/), your `ingress-nginx` `LoadBalancer` will be exposed on an IP address in your local network as above (`192.168.0.90`). If you're running `ingress-nginx` in EKS, you'll see an AWS load balancer domain name in this column instead.
@@ -179,7 +188,7 @@ If `ingress-nginx` is exposed with an IP address, create an `A` record in your D
 
 First, make sure you've followed the steps to [install the Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html). After you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
 
-yaml
+```yaml
 couchdb:
   persistentVolume:
     enabled: true
@@ -190,19 +199,18 @@ services:
     storageClass: "gp3"
   redis:
     storageClass: "gp3"
-
-
+```
 And then update your Budibase installation:
 
-
+```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
+```
 
 
 ### GCP GKE
 
 Follow the [guide to enable Compute Engine persistent disk](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver) in your GKE cluster. When you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
-
-
+```yaml
 couchdb:
   persistentVolume:
     enabled: true
@@ -213,20 +221,22 @@ services:
     storageClass: "standard-rwo"
   redis:
     storageClass: "standard-rwo"
-
+```
 
 And then update your Budibase installation:
 
-shell
+```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
+```
 
 
 ## Upgrading your Budibase version
 
 To upgrade to the latest version of Budibase via Helm, you can run the following command:
 
-shell
+```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --reuse-values
+```
 
 
 ***
@@ -237,7 +247,7 @@ helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --reuse
 
 You can scale up the number of pods in your installation by updating the `replicaCount` of a given service in the `values.yaml` of the Budibase helm chart. For example, if we wanted to scale up the worker and app service due to high load, we can update our `values.yaml` to have a higher `replicaCount`. Once updated, upgrade your chart to apply the changes.
 
-yaml
+```yaml
 services:
   proxy:
     replicaCount: 1
@@ -245,6 +255,7 @@ services:
     replicaCount: 2
   worker:
     replicaCount: 2
+```
 
 
 ### Secrets Management
@@ -257,7 +268,7 @@ If you have createSecrets set to true in your `values.yaml`, Budibase will creat
 * Object store secret key (if using MinIO)\
   If you need to read the value of your secrets, you can do so using `kubectl` and the following commands to read the values out from your k8s secrets:
 
-shell
+```shell
 # for internal API key
 kubectl get secret budibase-budibase -o go-template='{{ .data.internalApiKey }}' -n budibase | base64 --decode
 
@@ -269,44 +280,48 @@ kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreAccess 
 
 # MinIO Secret Key
 kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreSecret }}' -n budibase | base64 --decode
+```
 
 
 ### Redis
 
 The Budibase Helm chart ships with a [Redis](https://redis.io/) server that will be included by default. If you want to use your own external Redis cluster, you can configure the `values.yaml` file in the helm chart to switch off the Budibase one by turning enabled off. Here's what your configuration may look like if you wanted to disable the default bundled Redis and use an external Redis cluster hosted on `myrediscluster.io`.
 
-yaml yaml
+```yaml
   services:
     redis:
       enabled: false
       port: 6379
       url: "myrediscluster.io"
       password: "your-redis-password"
+```
 
 
 ### CouchDB
 
 The Budibase Helm chart will automatically bring up a one-node CouchDB cluster within your Kubernetes cluster. If you would rather use an existing CouchDB cluster, you can turn off the one Budibase supplies and point at your own. Please note - you must set up search in your [CouchDB cluster](https://docs.couchdb.org/en/stable/ddocs/search.html) in order to use all the search functionality that Budibase provides. Below is an example configuration of how you would point Budibase to a CouchDB installation hosted on `mycouch.io`:
 
-yaml
+```yaml
   services:
     couchdb:
       enabled: false
       url: "http://mycouch.io:1234"
       user: "couchuser"
       password: "couchpassword"
+```
 
 
 ### MinIO/Amazon S3
 
 Budibase ships with a MinIO server included for object storage. Since MinIO is Amazon S3 compliant, you can switch out the bundled MinIO for an S3 bucket in your AWS account. Here's how your **values.yaml** should look if you want to use S3 instead of MinIO.
 
-yaml
+```yaml
 services:  
   objectStore:
     minio: false
     accessKey: "your-access-key" # AWS_ACCESS_KEY
     secretKey: "your-secret-key" # AWS_SECRET_ACCESS_KEY
+```
 
 
 ### Reference

--- a/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
+++ b/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
@@ -76,17 +76,15 @@ Now that you have your Kubernetes cluster up and running, you can install the Bu
 helm install --create-namespace --namespace budibase budibase oci://ghcr.io/budibase/charts/budibase
 ```
 
-
 Wait a few moments as Budibase creates all the containers and resources. You can then run:
 
 ```shell
 kubectl get pods -n budibase
 ```
 
-
 You should now be able to see your new Budibase installation up and running in your Kubernetes cluster.
 
-
+```
 NAME                                READY   STATUS             RESTARTS         AGE
 app-service-69b7888b7-h25cp       1/1     Running            0                90m
 budibase-couchdb-0                1/1     Running            0                90m
@@ -94,7 +92,7 @@ minio-service-59c757bb5-q6xt2     1/1     Running            0                90
 proxy-service-6449dd9fdf-v5r6z    1/1     Running            0                90m
 redis-service-c6f59dcf5-lh7v5     1/1     Running            0                90m
 worker-service-55b49f4cdc-qr5b7   1/1     Running            0                90m
-
+```
 
 ## Configuring your Ingress resource
 
@@ -108,13 +106,11 @@ If you're running on AWS EKS, we ship an ALB-ready Ingress resource as part of t
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true
 ```
 
-
 If you want to enable ALB access logging to S3, you can set the following values during install or upgrade:
 
 ```shell
 --set awsAlbIngress.accessLogs.enabled=true --set awsAlbIngress.accessLogs.bucket=my-access-logs-bucket --set awsAlbIngress.accessLogs.prefix=budibase
 ```
-
 
 *Note: The S3 bucket must already exist in the same region as the ALB and have a bucket policy allowing the regional ELB log-delivery principal to write to it.*
 
@@ -125,7 +121,6 @@ $ kubectl --context qa -n budibase get ingress
 NAME               CLASS    HOSTS   ADDRESS                                                                 PORTS   AGE
 ingress-budibase   <none>   *       4372843243278.eu-west-1.elb.amazonaws.com   80      9m5s
 ```
-
 
 Visit the Ingress address in your browser and you will see that your Budibase installation is up and running.
 
@@ -138,7 +133,6 @@ If you'd like to set up HTTPS, you can also create a certificate using [AWS ACM]
 ```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true --set awsAlbIngress.certificateArn=...
 ```
-
 
 From here, if you'd like to use a custom domain name make sure it's a CNAME that points to Ingress address and that your certificate includes the custom domain name.
 
@@ -162,13 +156,11 @@ ingress:
                 number: 10000
 ```
 
-
 Save this as a file called `values.yaml` and then upgrade your Helm release:
 
 ```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
 ```
-
 
 Now find the external address if your `ingress-nginx` installation by running:
 
@@ -176,7 +168,6 @@ Now find the external address if your `ingress-nginx` installation by running:
 ➜ kubectl -n ingress-nginx get services | grep LoadBalancer
 ingress-nginx-controller                   LoadBalancer   10.99.103.243    192.168.0.90   80:32221/TCP,443:32172/TCP   2y20d
 ```
-
 
 If you're running a homelab with, for example, [metallb](https://metallb.org/), your `ingress-nginx` `LoadBalancer` will be exposed on an IP address in your local network as above (`192.168.0.90`). If you're running `ingress-nginx` in EKS, you'll see an AWS load balancer domain name in this column instead.
 
@@ -206,7 +197,6 @@ And then update your Budibase installation:
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
 ```
 
-
 ### GCP GKE
 
 Follow the [guide to enable Compute Engine persistent disk](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver) in your GKE cluster. When you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
@@ -229,7 +219,6 @@ And then update your Budibase installation:
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
 ```
 
-
 ## Upgrading your Budibase version
 
 To upgrade to the latest version of Budibase via Helm, you can run the following command:
@@ -237,7 +226,6 @@ To upgrade to the latest version of Budibase via Helm, you can run the following
 ```shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --reuse-values
 ```
-
 
 ***
 
@@ -256,7 +244,6 @@ services:
   worker:
     replicaCount: 2
 ```
-
 
 ### Secrets Management
 
@@ -282,7 +269,6 @@ kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreAccess 
 kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreSecret }}' -n budibase | base64 --decode
 ```
 
-
 ### Redis
 
 The Budibase Helm chart ships with a [Redis](https://redis.io/) server that will be included by default. If you want to use your own external Redis cluster, you can configure the `values.yaml` file in the helm chart to switch off the Budibase one by turning enabled off. Here's what your configuration may look like if you wanted to disable the default bundled Redis and use an external Redis cluster hosted on `myrediscluster.io`.
@@ -295,7 +281,6 @@ The Budibase Helm chart ships with a [Redis](https://redis.io/) server that will
       url: "myrediscluster.io"
       password: "your-redis-password"
 ```
-
 
 ### CouchDB
 
@@ -310,7 +295,6 @@ The Budibase Helm chart will automatically bring up a one-node CouchDB cluster w
       password: "couchpassword"
 ```
 
-
 ### MinIO/Amazon S3
 
 Budibase ships with a MinIO server included for object storage. Since MinIO is Amazon S3 compliant, you can switch out the bundled MinIO for an S3 bucket in your AWS account. Here's how your **values.yaml** should look if you want to use S3 instead of MinIO.
@@ -322,7 +306,6 @@ services:
     accessKey: "your-access-key" # AWS_ACCESS_KEY
     secretKey: "your-secret-key" # AWS_SECRET_ACCESS_KEY
 ```
-
 
 ### Reference
 

--- a/docs/Self-hosting/hosting-settings.md
+++ b/docs/Self-hosting/hosting-settings.md
@@ -274,6 +274,16 @@ The full set of variables can be found in our repo, in the file [.env](https://r
 
     <tr>
       <td>
+        RESOLVER
+      </td>
+
+      <td>
+        The DNS resolver the internal nginx proxy uses to resolve upstreams. This MUST be an IP address. If left empty in the Helm chart, Budibase will attempt to auto-detect the kube-dns ClusterIP.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
         SMTP_USER
       </td>
 


### PR DESCRIPTION
This PR updates the self-hosting documentation to reflect recent changes to the Budibase Helm chart, including:\n- Support for AWS ALB access logging to S3.\n- Manual configuration of the proxy DNS resolver via the `RESOLVER` variable.