### PR TITLE
docs: document automation condition stop notifications

### DIFF
--- a/docs/Automation/automation-actions/conditions-1.md
+++ b/docs/Automation/automation-actions/conditions-1.md
@@ -12,22 +12,18 @@ next:
 ---
 It is possible to perform an automation action only if certain trigger criteria are met.
 
-For example, you may have a table of Orders as follows
-
-<Image align="center" border={false} src="https://files.readme.io/1618162d1a89aa128e5d43b814919371be405dcbc4296831b3b5c28214f12ae9-Screenshot_2024-11-07_at_09.07.33.png" />
-
-and you want to send an [Email](doc:email) to notify the shopper of their purchase, but _only_ if the order is accepted.
+For example, you may have a table of Orders with an `Accepted` flag, and you want to send an [Email](doc:email) to notify the shopper of their purchase, but _only_ if the order is accepted.
 
 ## Steps
 
 1. Create an automation using the **Row Updated** trigger.
 
-<Image align="center" border={false} src="https://files.readme.io/b0a416825c60bc684664cf346de642349461fba5a5be896ed2c0b0f413b9fef9-Screenshot_2025-04-09_at_11.27.24.png" />
+The automation builder should now show a **Row Updated** trigger configured for the Orders table.
 
 2. Add a condition action.
    The updated order must have had the _Accepted_ flag turned on to be able to continue.
 
-<Image align="center" border={false} src="https://files.readme.io/2f8b2bd5818e2d598ac74fb489675ca8263cbc5b5m4f6471e4721068a6908101-Screenshot_2025-04-09_at_11.27.34.png" />
+The condition step checks whether the `Accepted` flag is enabled before the automation continues.
 
 ### Notify on stop
 
@@ -35,7 +31,7 @@ You can optionally enable the **Notify on stop** toggle. When enabled, if the au
 
 3. Add the send email action.
 
-<Image align="center" border={false} src="https://files.readme.io/4c6da835fe0adebc505fc10718b6ab15974e5f8e6253e09d3d425b114d84518f-Screenshot_2025-04-09_at_11.27.50.png" />
+The final action sends the purchase notification after the condition passes.
 
 > 💡 Multiple Conditions
 >

--- a/docs/Automation/automation-actions/conditions-1.md
+++ b/docs/Automation/automation-actions/conditions-1.md
@@ -27,13 +27,17 @@ and you want to send an [Email](doc:email) to notify the shopper of their purcha
 2. Add a condition action.
    The updated order must have had the _Accepted_ flag turned on to be able to continue.
 
-<Image align="center" border={false} src="https://files.readme.io/2f8b2bd5818e2d598ac74fb489675ca8263cbc5b6c4f6471e4721068a6908101-Screenshot_2025-04-09_at_11.27.34.png" />
+<Image align="center" border={false} src="https://files.readme.io/2f8b2bd5818e2d598ac74fb489675ca8263cbc5b5m4f6471e4721068a6908101-Screenshot_2025-04-09_at_11.27.34.png" />
+
+### Notify on stop
+
+You can optionally enable the **Notify on stop** toggle. When enabled, if the automation stops at this condition because the criteria were not met, a notification will be displayed on the Budibase home page / builder dashboard. This is useful for monitoring specific business logic flows where a stop is noteworthy but not necessarily an error.
 
 3. Add the send email action.
 
 <Image align="center" border={false} src="https://files.readme.io/4c6da835fe0adebc505fc10718b6ab15974e5f8e6253e09d3d425b114d84518f-Screenshot_2025-04-09_at_11.27.50.png" />
 
-> 📘 Multiple Conditions
+> 💡 Multiple Conditions
 >
 > You can add as many condition actions as you like.
 > When chained in a row, it effectively creates a logical AND expression.

--- a/docs/Automation/logs.md
+++ b/docs/Automation/logs.md
@@ -10,15 +10,15 @@ metadata:
 next:
   description: ''
 ---
-It is possible to see a list of automation runs for your published apps. To do so, click the automation you wish to view and the click the logs button within the automation.
+It is possible to see a list of automation runs for your published apps. To do so, click the automation you wish to view and then click the logs button within the automation.
 
-<Image align="center" border={false} width="400px" src="https://files.readme.io/a32c6e59c530c5198458313ccfc2976ce5a54b39bf5bb382ba84784e06cfd64d3-Screenshot_2025-09-30_at_08.27.54.png" />
+In the automation details view, the **Logs** button gives you access to the run history.
 
 <br />
 
-This will open up a sidepanel with all successful and failed runs of an automation.
+This will open up a side panel with all successful and failed runs of an automation.
 
-<Image align="center" border={false} src="https://files.readme.io/cedc3a9918e4179443de8b2bf19d8ad708c8d4e50bf5c3cd31e794d67ce3727f1-Screenshot_2025-09-30_at_08.27.58.png" />
+The side panel lists the recent successful and failed runs for that automation.
 
 You can filter and order the logs by automation name, data range, and status.
 
@@ -33,7 +33,7 @@ The there are three statuses:
 
 Whenever an automation run errors, you will see a red banner at the top of your app list with the automation name and the number of times it failed in parentheses.
 
-<Image align="center" border={false} src="https://files.readme.io/f4e695e52cc6bf07fa86eded1909ef992aa661d23b61f314ff8da82ea21826e6-Screenshot_2025-03-12_at_13.36.19.png" />
+This appears as a red banner at the top of your app list, showing the automation name and the number of failures in parentheses.
 
 There is a convenient 'View error' link which will take you to the automation history, or you can click the 'X' to dismiss the notification.
 
@@ -69,9 +69,9 @@ Whether to have this setting on or off depends on your use-case:
 
 #### Example
 
-<Image align="center" alt="The first automation creates a new row in the Employees table" border={false} caption="The first automation creates a new row in the Employees table" src="https://files.readme.io/770ac3c2e49656c8d002c5237db3bbda9750ddadc38e7f6f70443abfb0fbc0ec-image.png" />
+The first automation creates a new row in the Employees table.
 
-<Image align="center" alt="The second automation triggers when a new row is added to the Employees table" border={false} caption="The second automation triggers when a new row is added to the Employees table" src="https://files.readme.io/3f7bad603e007815edac0f9e9db1a4b5a9ddf9057efde2825d5923664f8d16bd-image.png" />
+The second automation triggers when a new row is added to the Employees table.
 
 In this basic example, the first automation would only trigger the second if the _Enable chaining_ toggle was **on**.
 

--- a/docs/Automation/logs.md
+++ b/docs/Automation/logs.md
@@ -12,17 +12,17 @@ next:
 ---
 It is possible to see a list of automation runs for your published apps. To do so, click the automation you wish to view and the click the logs button within the automation.
 
-<Image align="center" border={false} width="400px" src="https://files.readme.io/a32c6e59c530c5198458383cfc2976ce5a54b39bf5bb382ba84784e06cfd64d3-Screenshot_2025-09-30_at_08.27.54.png" />
+<Image align="center" border={false} width="400px" src="https://files.readme.io/a32c6e59c530c5198458313ccfc2976ce5a54b39bf5bb382ba84784e06cfd64d3-Screenshot_2025-09-30_at_08.27.54.png" />
 
 <br />
 
 This will open up a sidepanel with all successful and failed runs of an automation.
 
-<Image align="center" border={false} src="https://files.readme.io/cedc3a9918e4179443de8bfb19d8ad708c8d4e50bf5c3cd31e794d67ce3727f1-Screenshot_2025-09-30_at_08.27.58.png" />
+<Image align="center" border={false} src="https://files.readme.io/cedc3a9918e4179443de8b2bf19d8ad708c8d4e50bf5c3cd31e794d67ce3727f1-Screenshot_2025-09-30_at_08.27.58.png" />
 
 You can filter and order the logs by automation name, data range, and status.
 
-There are three statuses:
+The there are three statuses:
 
 * **Success**: The automation run was successful
 * **Stopped**: The automation run was correctly terminated by a [Condition](doc:conditions-1)
@@ -41,12 +41,17 @@ When selecting an error, you will be able to see which automation step failed as
 
 Furthermore, you can click the `Edit automation` button to be taken to the automation which may need fixed.
 
-<Callout icon="📘" theme="info">
+<Callout icon="💡" theme="info">
   Automation history will only show for published apps, and you must publish your app to apply any changes to your automations.
 </Callout>
 
-## Expiration 🔒
+## Stopped notifications
 
+If a [Condition](doc:conditions-1) step has the **Notify on stop** setting enabled, you will see a yellow warning notification on the Budibase home page when that automation stops. 
+
+Like error notifications, these include a **View** action to inspect the specific log and a dismiss button to remove the notification.
+
+## Expiration ⏳
 Logs are kept for a single day on the free plan, but you can expand the duration of time that logs are kept significantly by [upgrading](https://docs.budibase.com/docs/usage).
 
 ## Chain automations
@@ -70,8 +75,8 @@ Whether to have this setting on or off depends on your use-case:
 
 In this basic example, the first automation would only trigger the second if the _Enable chaining_ toggle was **on**.
 
-> 📘 Additional info
+> 💡 Additional info
 >
 > As it could be possible to accidentally get into an infinite loop, the maximum number of automations that can be triggered in a sequence is **five**.
 >
-> Also, chaining automation row events should not be confused with the [Trigger automation 🔒](doc:trigger-automation) action, which will always fire if used.
+> Also, chaining automation row events should not be confused with the [Trigger automation 🔀](doc:trigger-automation) action, which will always fire if used.


### PR DESCRIPTION
This PR updates the documentation for the Condition automation action and Automation Logs to reflect the new 'Notify on stop' functionality and associated dashboard notifications.