### PR TITLE
docs: update calendar settings and translation documentation

### DIFF
--- a/docs/Apps/components/calendar.md
+++ b/docs/Apps/components/calendar.md
@@ -236,7 +236,21 @@ On-click events can be established to surface the values for an event's `row_id`
       </td>
 
       <td>
+        Controls formatting of the weekday in the title area.
+      </td>
+    </tr>
 
+    <tr>
+      <td>
+        Weekday header format
+      </td>
+
+      <td>
+        Narrow or Short or Long
+      </td>
+
+      <td>
+        Controls formatting of the weekday labels in the table headers.
       </td>
     </tr>
 
@@ -295,63 +309,11 @@ On-click events can be established to surface the values for an event's `row_id`
         Calendar will open on current date by default. Set this to open on a specific date.
       </td>
     </tr>
-
-    <tr>
-      <td>
-        Month button Text
-      </td>
-
-      <td>
-        Text
-      </td>
-
-      <td>
-        Allows customisation for non-english-speaking users
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Week button Text
-      </td>
-
-      <td>
-        Text
-      </td>
-
-      <td>
-        Allows customisation for non-english-speaking users
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Day button text
-      </td>
-
-      <td>
-        Text
-      </td>
-
-      <td>
-        Allows customisation for non-english-speaking users
-      </td>
-    </tr>
-
-    <tr>
-      <td>
-        Today button text
-      </td>
-
-      <td>
-        Text
-      </td>
-
-      <td>
-        Allows customisation for non-english-speaking users
-      </td>
-    </tr>
   </tbody>
 </Table>
 
 <br />
+
+## Translations
+
+Calendar labels including weekday and month names, as well as button text (e.g. "Today", "Month", "Agenda"), are managed globally. You can customize these in [Workspace Translations](doc:translations) under the **Calendar** category.

--- a/docs/Settings/translations.md
+++ b/docs/Settings/translations.md
@@ -16,6 +16,7 @@ This feature enables users to change hard-coded values that appear throughout yo
 * Update Password
 * Go to the portal
 * Log out
+* Calendar (days, months, and component buttons)
 * And more...
 
 <Image border={false} src="https://files.readme.io/591841fe08a6188719a009c002d1be475d7048a3713960c29c76d81e2aff6e4a-image.png" />
@@ -30,6 +31,6 @@ For example, currently the user menu profile label is blank, so it will default 
 
 This will then appear across all apps within this workspace
 
-<Image align="center" border={false} src="https://files.readme.io/c8a7b170a2bceecf53269bece5338a3d0dce96e77719db7e59a9d935892069b8-image.png" />
+<Image align="center" border={false} src="https://files.readme.io/c8a7b170a2bceecf53269bece5338a3d0dce96e7719db7e59a9d935892069b8-image.png" />
 
 <br />

--- a/docs/Settings/translations.md
+++ b/docs/Settings/translations.md
@@ -31,6 +31,6 @@ For example, currently the user menu profile label is blank, so it will default 
 
 This will then appear across all apps within this workspace
 
-<Image align="center" border={false} src="https://files.readme.io/c8a7b170a2bceecf53269bece5338a3d0dce96e7719db7e59a9d935892069b8-image.png" />
+<Image align="center" border={false} src="https://files.readme.io/c8a7b170a2bceecf53269bece5338a3d0dce96e77719db7e59a9d935892069b8-image.png" />
 
 <br />


### PR DESCRIPTION
This PR updates the documentation for the Calendar component and Workspace Translations to reflect recent changes where calendar-related labels and buttons are now managed globally via system translations.\n\n- [Linked PR](https://github.com/Budibase/budibase/pull/19015)