### PR TITLE
docs: document BBAI_LITELLM_KEY requirement for self-hosted agents

### DIFF
--- a/docs/AI/agents-config.md
+++ b/docs/AI/agents-config.md
@@ -29,19 +29,19 @@ Make sure you have:
 5. Select or type a model
 6. Add a display name and save
 
-Once saved, the model becomes available in Agent model selection.
+once saved, the model becomes available in Agent model selection.
 
 ## Supported providers
 
 Budibase supports multiple model providers:
 
-| Provider    | Summary                                         |
-| :---------- | :---------------------------------------------- |
-| Budibase AI | Budibase-managed provider                       |
-| Anthropic   | Connect directly to Claude models               |
-| Google      | Connect directly to Gemini models               |
-| Mistral     | Connect directly to Mistral models              |
-| OpenAI      | Connect directly to OpenAI models               |
+| Provider    | Summary                                       |
+| :---------- | :-------------------------------------------- |
+| Budibase AI | Budibase-managed provider                     |
+| Anthropic   | Connect directly to Claude models              |
+| Google      | Connect directly to Gemini models              |
+| Mistral     | Connect directly to Mistral models             |
+| OpenAI      | Connect directly to OpenAI models              |
 | OpenRouter  | Connect to a broad catalog of hosted model APIs |
 | Groq        | Connect to high-speed hosted model APIs         |
 
@@ -95,7 +95,7 @@ If model connection or Agent tests fail:
 * Confirm outbound internet access is allowed from your environment
 * Re-run a simple prompt test after saving changes
 
-If you are self-hosting and using Budibase AI, ensure your network allows the required outbound traffic. See [Self-hosted AI features](doc:self-hosted-ai-features).
+If you are self-hosting and using Budibase AI, ensure the `BBAI_LITELLM_KEY` environment variable is correctly configured and available to every service that runs agents, including the automation worker. For more details on network requirements, see [Self-hosted AI features](doc:self-hosted-ai-features).
 
 ## Related guides
 

--- a/docs/Self-hosting/hosting-settings.md
+++ b/docs/Self-hosting/hosting-settings.md
@@ -173,7 +173,7 @@ The full set of variables can be found in our repo, in the file [.env](https://r
 
       <td>
         If you have lost access to your self host installation, or wish to bring a new install online with a default administration account you can use this environment variable to configure their username.  
-        _**We do not recommend leaving this set indefinitely, once the user has been created this should be removed.**_
+        _**We recommend not leaving this set indefinitely, once the user has been created this should be removed.**_
       </td>
     </tr>
 
@@ -184,7 +184,7 @@ The full set of variables can be found in our repo, in the file [.env](https://r
 
       <td>
         The password for the default administration account, used in conjunction with the `BB_ADMIN_USER_EMAIL` environment variable.  
-        _**We do not recommend leaving this set indefinitely, once the user has been created this should be removed.**_
+        _**We recommend not leaving this set indefinitely, once the user has been created this should be removed.**_
       </td>
     </tr>
 
@@ -348,7 +348,17 @@ The full set of variables can be found in our repo, in the file [.env](https://r
       </td>
 
       <td>
-        Controls which IP addresses/hostnames/CIDR subnets Budibase's outbound REST query integration is prevented from connecting to. This is an **SSRF (Server-Side Request Forgery) protection** mechanism. 
+        Controls which IP addresses/hostnames/CIDR subnets Budibase's outbound REST query integration is prevented from connecting to. This is an **SSRF (Server-Side Request Forgery) protection** mechanism.
+      </td>
+    </tr>
+
+    <tr>
+      <td>
+        BBAI_LITELLM_KEY
+      </td>
+
+      <td>
+        The virtual key used for Budibase AI services. This key is required for self-hosted agents to function correctly, particularly when executed within automations. Ensure this key is available to both the app service and the automation worker.
       </td>
     </tr>
   </tbody>


### PR DESCRIPTION
This PR updates the self-hosting and AI documentation to include the new `BBAI_LITELLM_KEY` environment variable, which is necessary for agents to function correctly in self-hosted environments—particularly when triggered via automations.\n\n- [Linked PR](https://github.com/Budibase/budibase/pull/19072)