### PR TITLE
docs: document relationship _id filtering and selection clearing

### DIFF
--- a/docs/Apps/pickers/filter-by-relationships.md
+++ b/docs/Apps/pickers/filter-by-relationships.md
@@ -124,7 +124,7 @@ For this tutorial we will use PostgreSQL, and assume there are three tables with
 * One Owner -> Many Pets
 * One Pet -> Many Appointments
 
-For a given owner, we we want to display a list of appointments based on the chosen pet. 
+For a given owner, we want to display a list of appointments based on the chosen pet. 
 
 Follow this [guide](https://docs.budibase.com/docs/postgresql-1) to see how to connect to your Postgres database, fetch the tables and define the relationships.
 

--- a/docs/Apps/pickers/filter-by-relationships.md
+++ b/docs/Apps/pickers/filter-by-relationships.md
@@ -21,7 +21,7 @@ The value column (the option value that will be saved) will be the **\_id** of t
 
 The **\_id** field represents a unique row identifier, which will exist on all data tables, including the internal DB and SQL tables within Budibase. It is a URL-safe encoded string.
 
-For testing purposes, you can copy the row **\_id** by right-clicking on a row in the **Data** section, and clicking `Copy row _id`. In the vast majority of cases you will not need to manually access the **\_id** field. 
+For testing purposes, you can copy the row **\_id** by right-clicking on a row in the **Data** section, and clicking `Copy row _id`. When setting up filters, the **\_id** field is explicitly available for selection within the field list for relationship fields (e.g., `Relationship._id`).
 
 <Image alt="Copy row \_id" align="center" src="https://files.readme.io/31a42fd-Screenshot_2023-08-11_at_09.40.03.png">
   Copy row \_id
@@ -59,9 +59,9 @@ While you can manually enter an array of hard-coded row identifiers, typically y
 4. Make sure the relationship picker is nested under the data provider
 5. Click the lightning bolt icon beside the *Default value* field of the relationship picker, and add the following JavaScript code:
 
-```javascript
+javascript
 return $("City Data Provider.Rows")?.map(row => row._id);
-```
+
 
 6. Refresh the page to see the default values load in
 
@@ -75,7 +75,7 @@ return $("City Data Provider.Rows")?.map(row => row._id);
 
 By default, the relationship picker options will be populated by all rows in the related table. This may be appropriate for small numbers of relationships, but for larger lists you will want to filter this down. Furthermore, there is a **hard limit of 100 options**, so if you have more than this you will need to apply a filter.
 
-You can add filters in the <Glossary>Settings Panel</Glossary> by clicking on the *Filtering* button.
+You can add filters in the <Glossary>Settings Panel</Glossary> by clicking on the *Filtering* button. When a filter is applied to a relationship picker, the current selection will automatically be cleared if the filter configuration or criteria change. This ensures that the selected values always remain valid based on the active filtering rules (e.g. in cascading dropdown scenarios).
 
 For example, only show related cities of the selected country:
 
@@ -92,7 +92,7 @@ For example, only show related cities of the selected country:
 You may want to perform an action when changing the relationship picker value. If you want to do something with the underlying related row data, then you will need to use the **Fetch Row** action.
 
 1. Click the button beside *On change* in the <Glossary>Settings Panel</Glossary>
-2. `Add action`: **Fetch Row** and select the table that matches the relationship table
+2. `Add actiona: **Fetch Row** and select the table that matches the relationship table
 3. Set the *Row ID* to `{{ Field Value }}`
 
 <Image alt="Fetching the selected row data" align="center" src="https://files.readme.io/77a8708-Screenshot_2023-08-14_at_13.32.59.png">
@@ -124,7 +124,7 @@ For this tutorial we will use PostgreSQL, and assume there are three tables with
 * One Owner -> Many Pets
 * One Pet -> Many Appointments
 
-For a given owner, we want to display a list of appointments based on the chosen pet. 
+For a given owner, we we want to display a list of appointments based on the chosen pet. 
 
 Follow this [guide](https://docs.budibase.com/docs/postgresql-1) to see how to connect to your Postgres database, fetch the tables and define the relationships.
 

--- a/docs/Apps/pickers/filter-by-relationships.md
+++ b/docs/Apps/pickers/filter-by-relationships.md
@@ -59,9 +59,9 @@ While you can manually enter an array of hard-coded row identifiers, typically y
 4. Make sure the relationship picker is nested under the data provider
 5. Click the lightning bolt icon beside the *Default value* field of the relationship picker, and add the following JavaScript code:
 
-javascript
+```javascript
 return $("City Data Provider.Rows")?.map(row => row._id);
-
+```
 
 6. Refresh the page to see the default values load in
 
@@ -92,7 +92,7 @@ For example, only show related cities of the selected country:
 You may want to perform an action when changing the relationship picker value. If you want to do something with the underlying related row data, then you will need to use the **Fetch Row** action.
 
 1. Click the button beside *On change* in the <Glossary>Settings Panel</Glossary>
-2. `Add actiona: **Fetch Row** and select the table that matches the relationship table
+2. `Add action`: **Fetch Row** and select the table that matches the relationship table
 3. Set the *Row ID* to `{{ Field Value }}`
 
 <Image alt="Fetching the selected row data" align="center" src="https://files.readme.io/77a8708-Screenshot_2023-08-14_at_13.32.59.png">


### PR DESCRIPTION
Updates the Relationship picker documentation to reflect improvements in filtering:\n- Related `_id` fields are now explicitly visible and selectable in the search/filter UI.\n- Relationship pickers now automatically clear their selection when their base filter criteria change (improving cascading dropdown behavior).\n\n- [Linked PR](https://github.com/Budibase/budibase/pull/19127)