### PR TITLE
docs: document OIDC email verification and linking settings

### DIFF
--- a/docs/Settings/authentication-and-sso/openid-connect.md
+++ b/docs/Settings/authentication-and-sso/openid-connect.md
@@ -61,6 +61,8 @@ Fill in the following options from your IdP:
   * Your unique ID issued by your IdP
 * **Client Secret**
   * Your unique secret issued by your IdP
+* **Allow unverified email linking**
+  * When disabled (default), Budibase will only link an SSO login to an existing local account if the identity provider confirms the email address is verified. Only enable this if you fully trust the provider to assert email addresses - otherwise it can allow account takeover.
 
 Save the configuration to enable OIDC on your login page.
 
@@ -98,4 +100,4 @@ Some additional details on the OIDC integration are highlighted below.
 
 Unlike the Google integration which requires a local user account to exist in advance, OIDC users are created in Budibase automatically when they log in for the first time. It is important that only the users you wish to access Budibase have been assigned to the application configured in your IdP.
 
-You may still use email onboarding to create an account for a user in advance, provided the email matches the user's email in your IdP.
+You may still use email onboarding to create an account for a user in advance, provided the email matches the user's email in your IdP. Note that by default, Budibase will only link an SSO login to an existing account if the identity provider confirms the email is verified (via the `email_verified` claim).


### PR DESCRIPTION
This PR updates the OpenID Connect documentation to include information about the new 'Allow unverified email linking' configuration option.\n\nKey changes:\n- Added 'Allow unverified email linking' to the OIDC configuration options list.\n- Added a note to the 'User provisioning' section explaining that Budibase now checks for the `email_verified` claim from the identity provider before linking SSO logins to existing local accounts.\n\nThese changes reflect the security enhancements merged in PR #19173.\n\n- [Linked PR](https://github.com/Budibase/budibase/pull/19173)