### PR TITLE
docs: document helm deployment and restart configuration

### DIFF
--- a/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
+++ b/docs/Self-hosting/hosting-methods/kubernetes-k8s.md
@@ -18,7 +18,7 @@ next:
       title: Reverse proxy
 ---
 <HTMLBlock>{`
-<div style="padding:65% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/712765075?h=b87fb892b5&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="k8-deployment.mp4"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
+<div style="padding:65% 0 0 0;position:relative;"><iframe src="https://player.vimeo.com/video/712765075?h=b87fb892b5&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479" frameborder="0" allow="autoplay; fullscreen; picture-in-picture" allowfullscreen style="position:absolute;top:0;left:0;width:100%;height:100%;" title="k8s-deployment.mp4"></iframe></div><script src="https://player.vimeo.com/api/player.js"></script>
 `}</HTMLBlock>
 
 There are a few command-line utilities we have to set up before we can get started with Budibase on Kubernetes. Follow the guides below to set up Kubectl and Helm.
@@ -26,7 +26,7 @@ There are a few command-line utilities we have to set up before we can get start
 * [helm CLI](https://helm.sh/docs/intro/install/)
 * [kubectl CLI](https://kubernetes.io/docs/tasks/tools/#kubectl)
 
-> 📘 Info
+> ℹ️ Info
 >
 > We recommend running on Kubernetes nodes with at least 1GB of memory, but we recommend larger instances for higher volume use cases.
 
@@ -72,27 +72,27 @@ If you want to make use of `HorizontalPodAutoscaler` resources you will also nee
 
 Now that you have your Kubernetes cluster up and running, you can install the Budibase Helm chart which will provision all of the relevant services for running Budibase in a Kubernetes environment. Run the command below to install the chart from our OCI registry.
 
-```shell
+shell
 helm install --create-namespace --namespace budibase budibase oci://ghcr.io/budibase/charts/budibase
-```
+
 
 Wait a few moments as Budibase creates all the containers and resources. You can then run:
 
-```shell
+shell
 kubectl get pods -n budibase
-```
+
 
 You should now be able to see your new Budibase installation up and running in your Kubernetes cluster.
 
-```
-NAME                                READY   STATUS             RESTARTS         AGE
+
+NAME                                       READY   STATUS             RESTARTS         AGE
 app-service-69b7888b7-h25cp       1/1     Running            0                90m
 budibase-couchdb-0                1/1     Running            0                90m
 minio-service-59c757bb5-q6xt2     1/1     Running            0                90m
 proxy-service-6449dd9fdf-v5r6z    1/1     Running            0                90m
 redis-service-c6f59dcf5-lh7v5     1/1     Running            0                90m
 worker-service-55b49f4cdc-qr5b7   1/1     Running            0                90m
-```
+
 
 ## Configuring your Ingress resource
 
@@ -102,25 +102,25 @@ To use your new installation, you'll need to configure an Ingress resource. One 
 
 If you're running on AWS EKS, we ship an ALB-ready Ingress resource as part of the chart. You'll need to disable the default Ingress and enable the ALB one:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true
-```
+
 
 If you want to enable ALB access logging to S3, you can set the following values during install or upgrade:
 
-```shell
+shell
 --set awsAlbIngress.accessLogs.enabled=true --set awsAlbIngress.accessLogs.bucket=my-access-logs-bucket --set awsAlbIngress.accessLogs.prefix=budibase
-```
+
 
 *Note: The S3 bucket must already exist in the same region as the ALB and have a bucket policy allowing the regional ELB log-delivery principal to write to it.*
 
 After a few minutes your new Ingress resource should be provisioned and you should be able to get the address for it like so:
 
-```shell
+shell
 $ kubectl --context qa -n budibase get ingress
-NAME               CLASS    HOSTS   ADDRESS                                                                 PORTS   AGE
+NAME               CLASS    HOSTS   ADDRESS                                                             PORTS   AGE
 ingress-budibase   <none>   *       4372843243278.eu-west-1.elb.amazonaws.com   80      9m5s
-```
+
 
 Visit the Ingress address in your browser and you will see that your Budibase installation is up and running.
 
@@ -130,9 +130,9 @@ Visit the Ingress address in your browser and you will see that your Budibase in
 
 If you'd like to set up HTTPS, you can also create a certificate using [AWS ACM](https://aws.amazon.com/certificate-manager/) and specify the certificate ARN on your Ingress resource:
 
-```shell
-helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true --set awsAlbIngress.certificateArn=...
-```
+shell
+helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --set ingress.enabled=false --set awsAlbIngress.enabled=true --set awsAlbIngress.certificateArn=..
+
 
 From here, if you'd like to use a custom domain name make sure it's a CNAME that points to Ingress address and that your certificate includes the custom domain name.
 
@@ -140,7 +140,7 @@ From here, if you'd like to use a custom domain name make sure it's a CNAME that
 
 If you're using `ingress-nginx` in your cluster, you'll want to configure an Ingress something like this (replacing `example.com` with whatever custom domain you would like to point at your Budibase installation):
 
-```yaml
+yaml
 ingress:
   enabled: true
   className: "nginx"
@@ -154,20 +154,20 @@ ingress:
               name: proxy-service
               port:
                 number: 10000
-```
+
 
 Save this as a file called `values.yaml` and then upgrade your Helm release:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
-```
+
 
 Now find the external address if your `ingress-nginx` installation by running:
 
-```shell
-➜ kubectl -n ingress-nginx get services | grep LoadBalancer
+shell
+❯ kubectl -n ingress-nginx get services | grep LoadBalancer
 ingress-nginx-controller                   LoadBalancer   10.99.103.243    192.168.0.90   80:32221/TCP,443:32172/TCP   2y20d
-```
+
 
 If you're running a homelab with, for example, [metallb](https://metallb.org/), your `ingress-nginx` `LoadBalancer` will be exposed on an IP address in your local network as above (`192.168.0.90`). If you're running `ingress-nginx` in EKS, you'll see an AWS load balancer domain name in this column instead.
 
@@ -179,7 +179,7 @@ If `ingress-nginx` is exposed with an IP address, create an `A` record in your D
 
 First, make sure you've followed the steps to [install the Amazon EBS CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html). After you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
 
-```yaml
+yaml
 couchdb:
   persistentVolume:
     enabled: true
@@ -190,60 +190,75 @@ services:
     storageClass: "gp3"
   redis:
     storageClass: "gp3"
-```
+
 And then update your Budibase installation:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
-```
+
 
 ### GCP GKE
 
 Follow the [guide to enable Compute Engine persistent disk](https://cloud.google.com/kubernetes-engine/docs/how-to/persistent-volumes/gce-pd-csi-driver) in your GKE cluster. When you've done that, add the following to your `values.yaml` to enable persistent storage for all of the Budibase services that need it:
-```yaml
+yaml
 couchdb:
   persistentVolume:
     enabled: true
     storageClass: "standard-rwo"
-   
+    
 services:
   objectStore:
     storageClass: "standard-rwo"
   redis:
     storageClass: "standard-rwo"
-```
+
 
 And then update your Budibase installation:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase -f values.yaml
-```
+
 
 ## Upgrading your Budibase version
 
 To upgrade to the latest version of Budibase via Helm, you can run the following command:
 
-```shell
+shell
 helm upgrade -n budibase budibase oci://ghcr.io/budibase/charts/budibase --reuse-values
-```
+
 
 ***
 
 ## Configuration
 
-### Scaling Budibase
+### Scaling and Deployment Configuration
 
-You can scale up the number of pods in your installation by updating the `replicaCount` of a given service in the `values.yaml` of the Budibase helm chart. For example, if we wanted to scale up the worker and app service due to high load, we can update our `values.yaml` to have a higher `replicaCount`. Once updated, upgrade your chart to apply the changes.
+You can scale up the number of pods in your installation by updating the `replicaCount` of a given service in the `values.yaml` of the Budibase helm chart. 
 
-```yaml
+For more control over your deployments, you can also configure the rollout strategy and image pull policy for each service. This is useful for optimizing rollout speed or managing mutable image tags.
+
+yaml
 services:
-  proxy:
-    replicaCount: 1
   apps:
     replicaCount: 2
+    # imagePullPolicy defaults to IfNotPresent
+    imagePullPolicy: Always
+    # Configure the rolling update strategy
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   worker:
     replicaCount: 2
-```
+
+
+#### Forcing a Restart
+
+If you need to trigger a rolling restart of your pods without changing the Budibase version (for example, to pick up changes in external configuration or a mutable image tag like `latest`), you can use the `globals.deployTimestamp` setting. Changing this value triggers a rollout of all deployment pods.
+
+yaml
+globals:
+  deployTimestamp: "2024-05-20T12:00:00Z"
+
 
 ### Secrets Management
 
@@ -255,7 +270,7 @@ If you have createSecrets set to true in your `values.yaml`, Budibase will creat
 * Object store secret key (if using MinIO)\
   If you need to read the value of your secrets, you can do so using `kubectl` and the following commands to read the values out from your k8s secrets:
 
-```shell
+shell
 # for internal API key
 kubectl get secret budibase-budibase -o go-template='{{ .data.internalApiKey }}' -n budibase | base64 --decode
 
@@ -267,45 +282,45 @@ kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreAccess 
 
 # MinIO Secret Key
 kubectl get secret budibase-budibase -o go-template='{{ .data.objectStoreSecret }}' -n budibase | base64 --decode
-```
+
 
 ### Redis
 
 The Budibase Helm chart ships with a [Redis](https://redis.io/) server that will be included by default. If you want to use your own external Redis cluster, you can configure the `values.yaml` file in the helm chart to switch off the Budibase one by turning enabled off. Here's what your configuration may look like if you wanted to disable the default bundled Redis and use an external Redis cluster hosted on `myrediscluster.io`.
 
-```yaml
+yaml
   services:
     redis:
       enabled: false
       port: 6379
       url: "myrediscluster.io"
       password: "your-redis-password"
-```
+
 
 ### CouchDB
 
 The Budibase Helm chart will automatically bring up a one-node CouchDB cluster within your Kubernetes cluster. If you would rather use an existing CouchDB cluster, you can turn off the one Budibase supplies and point at your own. Please note - you must set up search in your [CouchDB cluster](https://docs.couchdb.org/en/stable/ddocs/search.html) in order to use all the search functionality that Budibase provides. Below is an example configuration of how you would point Budibase to a CouchDB installation hosted on `mycouch.io`:
 
-```yaml
+yaml
   services:
     couchdb:
       enabled: false
       url: "http://mycouch.io:1234"
       user: "couchuser"
       password: "couchpassword"
-```
+
 
 ### MinIO/Amazon S3
 
 Budibase ships with a MinIO server included for object storage. Since MinIO is Amazon S3 compliant, you can switch out the bundled MinIO for an S3 bucket in your AWS account. Here's how your **values.yaml** should look if you want to use S3 instead of MinIO.
 
-```yaml
+yaml
 services:  
   objectStore:
     minio: false
     accessKey: "your-access-key" # AWS_ACCESS_KEY
     secretKey: "your-secret-key" # AWS_SECRET_ACCESS_KEY
-```
+
 
 ### Reference
 


### PR DESCRIPTION
Updates the Kubernetes self-hosting documentation to include information about the new deployment configuration options added to the Helm chart, including rollout strategy, image pull policy, and the `deployTimestamp` restart trigger.\n\n- [Linked PR](https://github.com/Budibase/budibase/pull/19183)