### PR TITLE
docs: document DNS rebinding protection and import security standardization

### DIFF
--- a/docs/Data/rest/rest-query-import.md
+++ b/docs/Data/rest/rest-query-import.md
@@ -32,6 +32,13 @@ Import lets you create multiple REST queries at once from API definitions.
 8. Open key queries and click **Send**
 9. Save any adjusted queries
 
+### Security validation
+
+When importing from a URL, Budibase applies the same security hardening and validation rules as the REST integration itself. This includes:
+* **Blacklist validation**: Preventing imports from blocked internal or sensitive hostnames.
+* **DNS Rebinding protection**: Request pinning to validated IP addresses to prevent host-switching during the import process.
+* **Protocol enforcement**: Only secure `http:` and `https:` protocols are permitted.
+
 ## Post-import hardening checklist
 
 1. Rename generic query names

--- a/docs/Self-hosting/running-budibase-behind-company-proxy.md
+++ b/docs/Self-hosting/running-budibase-behind-company-proxy.md
@@ -18,56 +18,60 @@ If you are running budibase in an environment where you need to use a proxy, suc
 
 There are 2 environment variables you will need to run budibase behind a company proxy:
 
-| Variable                   | Purpose                                                                          | Required |
-| :------------------------- | :------------------------------------------------------------------------------- | :------- |
-| `GLOBAL_AGENT_HTTP_PROXY`  | Where to proxy all server HTTP requests through                                  | Yes      |
-| `GLOBAL_AGENT_HTTPS_PROXY` | Where to proxy all server HTTPS requests through                                 | No       |
+| Variable                   | Purpose                                                                                    | Required |
+| :------------------------- | :----------------------------------------------------------------------------------------- | :------- |
+| `GLOBAL_AGENT_HTTP_PROXY`  | Where to proxy all server HTTP requests through                                             | Yes      |
+| `GLOBAL_AGENT_HTTPS_PROXY` | Where to proxy all server HTTPS requests through                                            | No       |
 | `GLOBAL_AGENT_NO_PROXY`    | A pattern of URLs that should be excluded from proxying. Eg. `*.foo.com,baz.com` | No       |
 
 Bear in mind that these variables need to be made available to both the `worker` and `app` services, so if using docker compose, you must add them to your docker compose configuration:
 
-```yaml YAML
+yaml YAML
 services:
   app-service:
     restart: unless-stopped
     image: budibase.docker.scarf.sh/budibase/apps
     container_name: bbapps
-    environment:
+    environtment:
      GLOBAL_AGENT_HTTP_PROXY: http://my-proxy.net
      GLOBAL_AGENT_HTTPS_PROXY: https://my-proxy.net
   worker-service:
     restart: unless-stopped
     image: budibase.docker.scarf.sh/budibase/apps
     container_name: bbworker
-    environment:
+    environtment:
       GLOBAL_AGENT_HTTP_PROXY: http://my-proxy.net
       GLOBAL_AGENT_HTTPS_PROXY: https://my-proxy.net
-```
 
-For container to container communication using `docker-compose` - you may need to add the following to avoid that local communication going through your proxy:
+
+For container to container communication using `docker-compose`  - you may need to add the following to avoid that local communication going through your proxy:
 
 `GLOBAL_AGENT_NO_PROXY: couchdb-service,app-service,worker-service,minio-service,redis-service,localhost`
 
 For single image setups, you can pass these environment variables using standard `docker run` syntax.
 
-```shell Bash
+shell Bash
 docker run -d -t 
 -e GLOBAL_AGENT_HTTP_PROXY=http://my-proxy.net 
 -p 10000:80 
 -v /local/path/data:/data  
 --restart unless-stopped 
 budibase/budibase:latest
-```
+
+
+### Security and DNS resolution
+
+When a proxy is configured, Budibase delegates DNS resolution for outbound requests to the proxy server. This means that internal security features, such as DNS rebinding protection (IP pinning), are managed by the proxy rather than the Budibase application server. Ensure your proxy is configured to enforce your organization's destination policies and network security standards.
 
 ### Outbound Allow-list
 
 To use your Budibase deployment, you must allow a list of outbound connections. These are as follows:
 
-| URL                                                                                                              | Purpose                                            |
-| :--------------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
-| [https://cdn.jsdelivr.net](https://cdn.jsdelivr.net)                                                             | Fonts                                              |
-| [https://fonts.gstatic.com](https://fonts.gstatic.com)                                                           | Fonts                                              |
-| [https://rsms.me](https://rsms.me)                                                                               | Fonts                                              |
-| [https://maxcdn.bootstrapcdn.com](https://maxcdn.bootstrapcdn.com)                                               | Fonts                                              |
-| [https://prod-budi-templates.s3-eu-west-1.amazonaws.com](https://prod-budi-templates.s3-eu-west-1.amazonaws.com) | App Templates                                      |
-| [https://account.budibase.app](https://account.budibase.app)                                                     | License check (only required for paying customers) |
+| URL                                                                                                         | Purpose                                           |
+| :---------------------------------------------------------------------------------------------------------- | :------------------------------------------------ |
+| [https://cdn.jsdelivr.net](https://cdn.jsdelivr.net)                                                        | Fonts                                             |
+| [https://fonts.gstatic.com](https://fonts.gstatic.com)                                                      | Fonts                                             |
+| [https://rsms.me](https://rsms.me)                                                                          | Fonts                                             |
+| [https://maxcdn.bootstrapcdn.com](https://maxcdn.bootstrapcdn.com)                                          | Fonts                                             |
+| [https://prod-budi-templates.s3-eu-west-1.amazonaws.com](https://prod-budi-templates.s3-eu-west-1.amazonaws.com) | App Templates                                     |
+| [https://account.budibase.app](https://account.budibase.app)                                                 | License check (only required for paying customers) |


### PR DESCRIPTION
This PR updates the documentation to reflect security hardening implemented in the REST integration and OpenAPI import modules. It clarifies that DNS rebinding protection is active and describes how this behavior changes when a company proxy is configured.\n\n- [Linked PR](https://github.com/Budibase/budibase/pull/19178)